### PR TITLE
Fix source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const SourceMapSource = require('webpack-sources').SourceMapSource;
+const RawSource = require('webpack-sources').RawSource;
 const postcss = require('postcss');
 
 class PostcssAssetWebpackPlugin {
@@ -15,12 +16,23 @@ class PostcssAssetWebpackPlugin {
 
       const promises = Object.keys(stats.assets).filter(name => path.extname(name) === '.css').map(name => {
         const css = stats.assets[name].source();
-        const map = stats.assets[name].map();
+
+        // Find source map if exists - could be separate asset or inline
+        const mapName = css.match(/\/\*# sourceMappingURL=(.+)\*\/|$/)[1];
+        const mapInline = mapName.search(/^data:/) === 0;
+        const mapAsset = mapInline ? null : stats.assets[mapName];
+
+        const map = mapAsset ? mapAsset.source()
+          : mapInline ? undefined // Postcss can read inlined sourcemap automatically
+          : stats.assets[name].map();
 
         return postcss(this.postcssOptions)
-          .process(css, {from: name, to: name, map: {prev: map}})
+          .process(css, {from: name, to: name, map: { inline: mapInline, sourcesContent: true, prev: map }})
           .then(result => {
             stats.assets[name] = new SourceMapSource(result.css, name, result.map)
+            if (mapAsset) {
+              stats.assets[mapName] = new RawSource(JSON.stringify(result.map));
+            }
           })
 
       });

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ class PostcssAssetWebpackPlugin {
 
         // Find source map if exists - could be separate asset or inline
         const mapName = css.match(/\/\*# sourceMappingURL=(.+)\*\/|$/)[1];
-        const mapInline = mapName.search(/^data:/) === 0;
-        const mapAsset = mapInline ? null : stats.assets[mapName];
+        const mapInline = mapName ? mapName.search(/^data:/) === 0 : false;
+        const mapAsset = mapName && !mapInline ? stats.assets[mapName] : null;
 
         const map = mapAsset ? mapAsset.source()
           : mapInline ? undefined // Postcss can read inlined sourcemap automatically


### PR DESCRIPTION
I wasn't getting a working sourcemap from this plugin. I tried using both external and inline sourcemaps and neither worked.

This PR reads gets Postcss to read any existing sourcemap from previous loaders, and sets external sourcemap asset if using.